### PR TITLE
faster install step when no wildcard in package name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ telegraf_group: "{{ telegraf_user }}"
 #############
 ## Package
 telegraf_version: '*'                # e.g. 0.13.0 or '*' for latest
+telegraf_pkg: '{{ "telegraf" if telegraf_version == "*" else "telegraf" + "-" + telegraf_version}}'
 telegraf_signing_key_url: "https://repos.influxdata.com/influxdb.key" 
 telegraf_apt_repo: "deb https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} stable" 
 telegraf_yum_repo_baseurl: 'https://repos.influxdata.com/centos/\$releasever/\$basearch/stable'

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -21,6 +21,6 @@
 
 - name: Install telegraf
   yum:
-    name:  "telegraf-{{ telegraf_version|default('*') }}"
+    name:  "{{ telegraf_pkg }}"
     update_cache: yes
     state: present


### PR DESCRIPTION
When re-running playbook, install step takes a lot of time if pkg_name-* is specified in yum args.